### PR TITLE
Configure hosted documentation URL on the Swift Package Index

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,3 @@
+version: 1
+external_links:
+  documentation: "https://rryam.github.io/MusadoraKit/documentation/musadorakit/"


### PR DESCRIPTION
Hello 👋 I noticed you have a link in your README to hosted DocC documentation. This file will add a "Documentation" link to the MusadoraKit page on the Swift Package Index that will send people to your hosted documentation.