### PR TITLE
Add methods for reference content across different geographical regions & map explicit to clean-equivalent content.

### DIFF
--- a/Sources/MusadoraKit/Catalog/CatalogAlbum.swift
+++ b/Sources/MusadoraKit/Catalog/CatalogAlbum.swift
@@ -5,8 +5,6 @@
 //  Created by Rudrank Riyam on 14/08/21.
 //
 
-
-
 public extension MCatalog {
   /// Fetch an album from the Apple Music catalog by using its identifier.
   ///

--- a/Sources/MusadoraKit/Catalog/CatalogArtist.swift
+++ b/Sources/MusadoraKit/Catalog/CatalogArtist.swift
@@ -5,8 +5,6 @@
 //  Created by Rudrank Riyam on 25/08/21.
 //
 
-
-
 public extension MCatalog {
   /// Fetch an artist from the Apple Music catalog by using its identifier.
   /// - Parameters:

--- a/Sources/MusadoraKit/Catalog/CatalogChart.swift
+++ b/Sources/MusadoraKit/Catalog/CatalogChart.swift
@@ -5,9 +5,6 @@
 //  Created by Rudrank Riyam on 22/06/22.
 //
 
-import Foundation
-
-
 #if compiler(>=5.7)
 @available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
 public enum MusicCatalogChartType {

--- a/Sources/MusadoraKit/Catalog/CatalogCurator.swift
+++ b/Sources/MusadoraKit/Catalog/CatalogCurator.swift
@@ -5,8 +5,6 @@
 //  Created by Rudrank Riyam on 10/04/22.
 //
 
-
-
 @available(iOS 15.4, macOS 12.3, tvOS 15.4, watchOS 9.0, *)
 public extension MCatalog {
 

--- a/Sources/MusadoraKit/Catalog/CatalogGenre.swift
+++ b/Sources/MusadoraKit/Catalog/CatalogGenre.swift
@@ -5,7 +5,6 @@
 //  Created by Rudrank Riyam on 17/08/21.
 //
 
-
 import Foundation
 
 public extension MCatalog {
@@ -78,7 +77,13 @@ public extension MCatalog {
 
       for storefront in storefronts {
         group.addTask {
-          let url = URL(string: "https://api.music.apple.com/v1/catalog/\(storefront)/genres")!
+          var components = AppleMusicURLComponents()
+          components.path = "catalog/\(storefront)/genres"
+
+          guard let url = components.url else {
+            throw URLError(.badURL)
+          }
+
           let request = MusicDataRequest(urlRequest: .init(url: url))
           let response = try await request.response()
 
@@ -107,10 +112,10 @@ public extension MCatalog {
   /// - Returns: `StationGenres` representing the list of station genres available in the current country's storefront.
   static func stationGenres() async throws -> StationGenres {
     let storefront = try await MusicDataRequest.currentCountryCode
+    var components = AppleMusicURLComponents()
+    components.path = "catalog/\(storefront)/station-genres"
 
-    let url = URL(string: "https://api.music.apple.com/v1/catalog/\(storefront)/station-genres")
-    
-    guard let url = url else {
+    guard let url = components.url else {
       throw URLError(.badURL)
     }
 
@@ -126,9 +131,10 @@ public extension MCatalog {
   ///
   /// - Returns: `StationGenres` representing the list of station genres available in the current country's storefront.
   static func stationGenres(for storefront: StorefrontsData.Storefront) async throws -> StationGenres {
-    let url = URL(string: "https://api.music.apple.com/v1/catalog/\(storefront.id)/station-genres")
+    var components = AppleMusicURLComponents()
+    components.path = "catalog/\(storefront.id)/station-genres"
 
-    guard let url = url else {
+    guard let url = components.url else {
       throw URLError(.badURL)
     }
 

--- a/Sources/MusadoraKit/Catalog/CatalogMusicVideo.swift
+++ b/Sources/MusadoraKit/Catalog/CatalogMusicVideo.swift
@@ -5,8 +5,6 @@
 //  Created by Rudrank Riyam on 08/09/21.
 //
 
-
-
 public extension MCatalog {
   /// Fetch a music video from the Apple Music catalog by using its identifier.
   /// - Parameters:

--- a/Sources/MusadoraKit/Catalog/CatalogPlaylist.swift
+++ b/Sources/MusadoraKit/Catalog/CatalogPlaylist.swift
@@ -202,11 +202,3 @@ public extension MCatalog {
     return globalChartPlaylists
   }
 }
-
-extension Array where Element == String {
-    func chunked(into size: Int) -> [[Element]] {
-        return stride(from: 0, to: count, by: size).map {
-            Array(self[$0 ..< Swift.min($0 + size, count)])
-        }
-    }
-}

--- a/Sources/MusadoraKit/Catalog/CatalogRadioShow.swift
+++ b/Sources/MusadoraKit/Catalog/CatalogRadioShow.swift
@@ -5,8 +5,6 @@
 //  Created by Rudrank Riyam on 10/04/22.
 //
 
-
-
 @available(iOS 15.4, macOS 12.3, tvOS 15.4, watchOS 9.0, *)
 public extension MCatalog {
   /// Fetch a radio show from the Apple Music catalog by using its identifier.

--- a/Sources/MusadoraKit/Catalog/CatalogRecordLabel.swift
+++ b/Sources/MusadoraKit/Catalog/CatalogRecordLabel.swift
@@ -5,8 +5,6 @@
 //  Created by Rudrank Riyam on 10/04/22.
 //
 
-
-
 public extension MCatalog {
   /// Fetch a record label from the Apple Music catalog by using its identifier.
   /// - Parameters:

--- a/Sources/MusadoraKit/Catalog/CatalogSearch.swift
+++ b/Sources/MusadoraKit/Catalog/CatalogSearch.swift
@@ -5,8 +5,6 @@
 //  Created by Rudrank Riyam on 20/08/21.
 //
 
-
-
 public extension MCatalog {
   /// Search the Apple Music catalog by using a query term.
   /// - Parameters:

--- a/Sources/MusadoraKit/Catalog/CatalogStation.swift
+++ b/Sources/MusadoraKit/Catalog/CatalogStation.swift
@@ -5,7 +5,6 @@
 //  Created by Rudrank Riyam on 14/08/21.
 //
 
-
 import Foundation
 
 public extension MCatalog {
@@ -79,10 +78,10 @@ public extension MCatalog {
   /// - Returns: `Stations` representing the list of stations belonging to the specified genre.
   static func stations(for genre: StationGenre) async throws -> Stations {
     let storefront = try await MusicDataRequest.currentCountryCode
+    var components = AppleMusicURLComponents()
+    components.path = "catalog/\(storefront)/station-genres/\(genre.id.rawValue)/stations"
 
-    let url = URL(string: "https://api.music.apple.com/v1/catalog/\(storefront)/station-genres/\(genre.id.rawValue)/stations")
-
-    guard let url = url else {
+    guard let url = components.url else {
       throw URLError(.badURL)
     }
 
@@ -117,7 +116,6 @@ public extension MCatalog {
 
   static func personalStation() async throws -> Station {
     let storefront = try await MusicDataRequest.currentCountryCode
-
     var components = AppleMusicURLComponents()
     components.path = "catalog/\(storefront)/stations"
     components.queryItems = [URLQueryItem(name: "filter[identity]", value: "personal")]

--- a/Sources/MusadoraKit/Catalog/MCatalogSearchType.swift
+++ b/Sources/MusadoraKit/Catalog/MCatalogSearchType.swift
@@ -5,8 +5,6 @@
 //  Created by Rudrank Riyam on 22/12/22.
 //
 
-
-
 public typealias MCatalogSearchTypes = [MCatalogSearchType]
 
 public enum MCatalogSearchType {

--- a/Sources/MusadoraKit/Equivalents/CatalogCleanEquivalent.swift
+++ b/Sources/MusadoraKit/Equivalents/CatalogCleanEquivalent.swift
@@ -1,28 +1,31 @@
 //
-//  LibraryCatalog.swift
+//  CatalogCleanEquivalent.swift
 //  MusadoraKit
 //
-//  Created by Rudrank Riyam on 10/05/22.
+//  Created by Rudrank Riyam on 18/03/23.
 //
 
 import Foundation
 
-public extension FilterableLibraryItem {
-  var catalog: Self {
+public extension EquivalentRequestable {
+  var clean: Self {
     get async throws {
-      let path: LibraryMusicItemType
+      let path: EquivalentMusicItemType
+      let storefront = try await MusicDataRequest.currentCountryCode
       var components = AppleMusicURLComponents()
 
       switch self {
         case is Song: path = .songs
         case is Album: path = .albums
-        case is Artist: path = .artists
         case is MusicVideo: path = .musicVideos
-        case is Playlist: path = .playlists
-        default: throw NSError(domain: "Wrong library music item type.", code: 0)
+        default: throw NSError(domain: "Wrong equivalent music item type.", code: 0)
       }
 
-      components.path = "me/library/\(path.rawValue)/\(id.rawValue)/catalog"
+      components.path = "catalog/\(storefront)/\(path.rawValue)"
+
+      let filterEquivalentsQuery = URLQueryItem(name: "filter[equivalents]", value: id.rawValue)
+      let restrictExplicitQuery = URLQueryItem(name: "restrict", value: "explicit")
+      components.queryItems = [filterEquivalentsQuery, restrictExplicitQuery]
 
       guard let url = components.url else {
         throw URLError(.badURL)

--- a/Sources/MusadoraKit/Equivalents/CatalogEquivalent.swift
+++ b/Sources/MusadoraKit/Equivalents/CatalogEquivalent.swift
@@ -1,0 +1,38 @@
+//
+//  CatalogEquivalent.swift
+//  MusadoraKit
+//
+//  Created by Rudrank Riyam on 18/03/23.
+//
+
+import Foundation
+
+public extension EquivalentRequestable {
+  func equivalent(for targetStorefront: String) async throws -> Self {
+    let path: EquivalentMusicItemType
+    var components = AppleMusicURLComponents()
+
+    switch self {
+      case is Song: path = .songs
+      case is Album: path = .albums
+      case is MusicVideo: path = .musicVideos
+      default: throw NSError(domain: "Wrong equivalent music item type.", code: 0)
+    }
+
+    components.path = "catalog/\(targetStorefront)/\(path.rawValue)"
+    components.queryItems = [URLQueryItem(name: "filter[equivalents]", value: id.rawValue)]
+
+    guard let url = components.url else {
+      throw URLError(.badURL)
+    }
+
+    let request = MusicDataRequest(urlRequest: .init(url: url))
+    let response = try await request.response()
+    let items = try JSONDecoder().decode(MusicItemCollection<Self>.self, from: response.data)
+
+    guard let item = items.first else {
+      throw MusadoraKitError.notFound(for: id.rawValue)
+    }
+    return item
+  }
+}

--- a/Sources/MusadoraKit/Equivalents/EquivalentMusicItemType.swift
+++ b/Sources/MusadoraKit/Equivalents/EquivalentMusicItemType.swift
@@ -1,0 +1,14 @@
+//
+//  EquivalentMusicItemType.swift
+//  MusadoraKit
+//
+//  Created by Rudrank Riyam on 18/03/23.
+//
+
+import Foundation
+
+enum EquivalentMusicItemType: String, Codable {
+  case songs
+  case albums
+  case musicVideos = "music-videos"
+}

--- a/Sources/MusadoraKit/Equivalents/EquivalentRequestable.swift
+++ b/Sources/MusadoraKit/Equivalents/EquivalentRequestable.swift
@@ -1,0 +1,20 @@
+//
+//  EquivalentRequestable.swift
+//  MusadoraKit
+//
+//  Created by Rudrank Riyam on 18/03/23.
+//
+
+/// A protocol for music items that your app can fetch by
+/// using a equivalent request.
+public protocol EquivalentRequestable: MusicItem, Codable {
+}
+
+extension Album: EquivalentRequestable {
+}
+
+extension Song: EquivalentRequestable {
+}
+
+extension MusicVideo: EquivalentRequestable {
+}

--- a/Sources/MusadoraKit/Extension/Array.swift
+++ b/Sources/MusadoraKit/Extension/Array.swift
@@ -17,3 +17,11 @@ extension Array where Element: Equatable {
     }
   }
 }
+
+extension Array where Element == String {
+  func chunked(into size: Int) -> [[Element]] {
+    return stride(from: 0, to: count, by: size).map {
+      Array(self[$0 ..< Swift.min($0 + size, count)])
+    }
+  }
+}

--- a/Sources/MusadoraKit/Library/Resource Request/FilterableLibraryItem.swift
+++ b/Sources/MusadoraKit/Library/Resource Request/FilterableLibraryItem.swift
@@ -5,8 +5,6 @@
 //  Created by Rudrank Riyam on 02/04/22.
 //
 
-
-
 /// A declaration of the associated type that contains the set of library music item
 /// properties your app uses as a filter for a library resource request.
 public protocol FilterableLibraryItem: MusicItem, Decodable {


### PR DESCRIPTION
Usage: 

 - Referencing content across different geographical regions. In the example below, the target storefront is "tw" for Taiwan:
 
```swift 
let newAlbum = try await album.equivalent(for: "tw")
```

-  Map explicit to clean-equivalent content:
```swift 
let cleanSong = try await song.clean
```

> Note: For both methods, you can only get the equivalents for songs, albums, and music videos. 

TO DO: 
- Add methods to get batch equivalents for a collection of songs, albums, and music videos. 

