### PR TITLE
Fix the equivalent decode format

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ I am slowly adding all the methods used in MusadoraKit to it, so you can refer t
 
 ## Apps Using MusadoraKit
 
+- [Music Mate](https://apps.apple.com/app/musicmate-music-map-friends/id1605379758): Meet music friends on the world map.
 - [Sonar](https://apps.apple.com/ca/app/sonar-music-community/id1626147292): Music & Community. Stream, Share & Discover
 - [Tuneder](https://apps.apple.com/us/app/tuneder-song-discovery/id6450867856?itsct=apps_box_badge&itscg=30200): An [open-source](https://github.com/adityasaravana/Tuneder) iOS app that helps Apple Music users discover new songs with a Tinder-like UI.
 - Musadora: Apple Music client focused on playlists

--- a/Sources/MusadoraKit/Equivalents/CatalogEquivalent.swift
+++ b/Sources/MusadoraKit/Equivalents/CatalogEquivalent.swift
@@ -84,7 +84,7 @@ public extension MCatalog {
   /// - Returns: The equivalent music item of type `T` found in the specified storefront.
   /// - Throws:
   ///     - An error if the network request fails or the response cannot be decoded.
-  static func equivalent<T: StorefrontRequestable>(id: MusicItemID, targetStorefront: String) async throws -> T {
+  static func equivalent<T: StorefrontRequestable>(id: MusicItemID, targetStorefront: String) async throws -> MusicItemCollection<T> {
     var components = AppleMusicURLComponents()
     components.path = "catalog/\(targetStorefront)/\(T.resourcePath)/\(id)"
     components.queryItems = [URLQueryItem(name: "filter[equivalents]", value: id.rawValue)]
@@ -95,7 +95,7 @@ public extension MCatalog {
 
     let request = MusicDataRequest(urlRequest: .init(url: url))
     let response = try await request.response()
-    let item = try JSONDecoder().decode(T.self, from: response.data)
-    return item
+    let items = try JSONDecoder().decode(MusicItemCollection<T>.self, from: response.data)
+    return items
   }
 }


### PR DESCRIPTION
Instead of `let usSong: Song = try await MCatalog.equivalent(id: “1642657180”, targetStorefront: “us”)` we should use `let usSongs: MusicItemCollection<Song> = try await MCatalog.equivalent(id: “1642657180”, targetStorefront: “us”)` because of the decode format.

And I've also attached [Music Mate](https://apps.apple.com/app/musicmate-music-map-friends/id1605379758) to the list as your excellent project is in use in our app.

Thanks! 