### PR TITLE
Allow 204 as success code

### DIFF
--- a/Sources/MusadoraKit/Add Resources/CreatePlaylist.swift
+++ b/Sources/MusadoraKit/Add Resources/CreatePlaylist.swift
@@ -305,7 +305,7 @@ public extension MLibrary {
 
     let request = MDataPostRequest(url: url, data: data)
     let response = try await request.response()
-    return response.urlResponse.statusCode == 201
+    return [201, 204].contains(response.urlResponse.statusCode)
   }
 
   /// Adds an array of songs to a specified playlist in the user's music library.


### PR DESCRIPTION
Fixes #53. Apple Music sends back a 204 when adding a song to a playlist, so this also needs to be a success code.